### PR TITLE
Updated `@sveltejs/vite-plugin-svelte` specifier to fix new plugin versions support

### DIFF
--- a/@lib/package.json
+++ b/@lib/package.json
@@ -40,7 +40,7 @@
     "@tanstack/svelte-query": "^5.8.2",
     "@trpc/client": "^10.43.3",
     "@trpc/server": "^10.43.3",
-    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "@sveltejs/vite-plugin-svelte": ">=4.0.0 <6",
     "svelte": "^5",
     "typescript": "^5.2.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,7 +110,7 @@ importers:
   '@lib':
     dependencies:
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^4.0.0
+        specifier: '>=4.0.0 <6'
         version: 4.0.1(svelte@5.2.1)(vite@5.3.3(@types/node@20.14.10)(sass@1.77.8))
       '@tanstack/svelte-query':
         specifier: ^5.8.2
@@ -2542,7 +2542,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -2571,7 +2571,7 @@ snapshots:
       estree-walker: 2.0.2
       glob: 10.4.5
       is-reference: 1.2.1
-      magic-string: 0.30.10
+      magic-string: 0.30.12
     optionalDependencies:
       rollup: 4.18.1
 
@@ -2594,7 +2594,7 @@ snapshots:
 
   '@rollup/pluginutils@5.1.0(rollup@4.18.1)':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
@@ -2819,7 +2819,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.0.0-alpha.41(typescript@5.5.3)
       '@typescript-eslint/utils': 8.0.0-alpha.41(eslint@9.6.0)(typescript@5.5.3)
-      debug: 4.3.5
+      debug: 4.3.7
       ts-api-utils: 1.3.0(typescript@5.5.3)
     optionalDependencies:
       typescript: 5.5.3
@@ -2833,7 +2833,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.0.0-alpha.41
       '@typescript-eslint/visitor-keys': 8.0.0-alpha.41
-      debug: 4.3.5
+      debug: 4.3.7
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -3450,7 +3450,7 @@ snapshots:
 
   is-reference@1.2.1:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   is-reference@3.0.2:
     dependencies:


### PR DESCRIPTION
Fixes the following peer dependency warning by allowing newer versions

```
└─┬ trpc-svelte-query-adapter 2.3.15
  └── ✕ unmet peer @sveltejs/vite-plugin-svelte@^4.0.0: found 5.0.3
```

I've been using it like this without issue as of yet,

Tested to match currently known good versions up to before version 6 (which doesn't yet exist)

https://semver.otterlord.dev/?package=%40sveltejs%2Fvite-plugin-svelte&range=%3E%3D4.0.0+%3C6&filter=on